### PR TITLE
Subscription payment key expects payment type

### DIFF
--- a/src/DataTypes/Subscription.php
+++ b/src/DataTypes/Subscription.php
@@ -23,7 +23,7 @@ class Subscription extends BaseDataType
 
     public function addPayment(PaymentMethodInterface $payment)
     {
-        $this->properties['payment'] = $payment->toArray();
+        $this->properties['payment'][$payment->getType()] = $payment->toArray();
     }
 
     public function addOrder(Order $order)


### PR DESCRIPTION
This is required if you are creating a subscription from payment data directly.