### PR TITLE
Add support for Accept Hosted Payment Page and Customer Profiles from transactions.

### DIFF
--- a/src/AuthenticateTestRequest.php
+++ b/src/AuthenticateTestRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace CommerceGuys\AuthNet;
+
+use CommerceGuys\AuthNet\DataTypes\MerchantAuthentication;
+use CommerceGuys\AuthNet\Request\RequestInterface;
+
+/**
+ * Represents the authenticateTestRequest endpoint for testing API credentials.
+ *
+ * This request verifies that the provided API Login ID and Transaction Key
+ * are valid and that the merchant is authorized to submit transactions.
+ *
+ * Commonly used to validate configuration forms or connectivity.
+ *
+ * @link https://developer.authorize.net/api/reference/index.html#gettingstarted-section-section-header
+ */
+class AuthenticateTestRequest extends BaseApiRequest
+{
+
+    /**
+     * Sets the merchant authentication credentials.
+     *
+     * @param \CommerceGuys\AuthNet\DataTypes\MerchantAuthentication $merchantAuthentication
+     *
+     * @return $this
+     */
+    public function setMerchantAuthentication(MerchantAuthentication $merchantAuthentication): self
+    {
+        $this->merchantAuthentication = $merchantAuthentication;
+        return $this;
+    }
+
+    /**
+     * Gets the merchant authentication credentials.
+     *
+     * @return \CommerceGuys\AuthNet\DataTypes\MerchantAuthentication|null
+     */
+    public function getMerchantAuthentication(): ?MerchantAuthentication
+    {
+        return $this->merchantAuthentication;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function attachData(RequestInterface $request): void
+    {
+        // Only attach merchant authentication if available.
+        if ($this->merchantAuthentication) {
+            $request->addDataType($this->merchantAuthentication);
+        }
+    }
+}

--- a/src/CreateCustomerProfileFromTransactionRequest.php
+++ b/src/CreateCustomerProfileFromTransactionRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace CommerceGuys\AuthNet;
+
+use GuzzleHttp\Client;
+use CommerceGuys\AuthNet\Request\RequestInterface;
+
+/**
+ * Creates a customer profile, payment profile, and shipping address
+ * from an existing successful transaction.
+ *
+ * This request uses a transaction ID (`transId`) from a prior successful
+ * payment to generate a new customer profile in Authorize.Net.
+ *
+ * @link https://developer.authorize.net/api/reference/index.html#customer-profiles-create-a-customer-profile-from-a-transaction
+ */
+class CreateCustomerProfileFromTransactionRequest extends BaseApiRequest
+{
+    /**
+     * @var string The transaction ID from a successful payment.
+     */
+    protected $transId;
+
+    /**
+     * Constructs a new CreateCustomerProfileFromTransactionRequest object.
+     *
+     * @param Configuration $configuration
+     *   The configuration object containing API credentials.
+     * @param Client $client
+     *   The HTTP client for making requests.
+     * @param string $transId
+     *   The transaction ID from an existing successful transaction.
+     */
+    public function __construct(
+        Configuration $configuration,
+        Client $client,
+        $transId
+    ) {
+        parent::__construct($configuration, $client);
+        $this->transId = $transId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function attachData(RequestInterface $request)
+    {
+        $request->addData('transId', $this->transId);
+    }
+}

--- a/src/DataTypes/HostedPaymentSettings.php
+++ b/src/DataTypes/HostedPaymentSettings.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CommerceGuys\AuthNet\DataTypes;
+
+/**
+ * Collection of hosted payment settings.
+ */
+class HostedPaymentSettings extends BaseDataType
+{
+
+    /**
+     * Adds a setting to the hosted payment configuration.
+     *
+     * @param Setting $setting
+     */
+    public function addSetting(Setting $setting): void
+    {
+        $this->properties[] = ['setting' => $setting->toArray()];
+    }
+}

--- a/src/DataTypes/HostedPaymentSettings.php
+++ b/src/DataTypes/HostedPaymentSettings.php
@@ -17,4 +17,18 @@ class HostedPaymentSettings extends BaseDataType
     {
         $this->properties[] = ['setting' => $setting->toArray()];
     }
+
+    /**
+     * Removes setting from the hosted payment configuration.
+     *
+     * @param string $name
+     */
+    public function removeSetting(string $name): void
+    {
+        foreach ($this->properties as $key => $property) {
+            if ($property['setting']['settingName'] == $name) {
+                unset($this->properties[$key]);
+            }
+        }
+    }
 }

--- a/src/DataTypes/Setting.php
+++ b/src/DataTypes/Setting.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CommerceGuys\AuthNet\DataTypes;
+
+/**
+ * Represents a single setting used in HostedPaymentSettings.
+ *
+ * @see \CommerceGuys\AuthNet\DataTypes\HostedPaymentSettings
+ */
+class Setting extends BaseDataType
+{
+
+    protected $propertyMap = [
+        'settingName',
+        'settingValue',
+    ];
+
+    /**
+     * Constructs a new Setting object.
+     *
+     * @param string $name
+     *   The name of the setting (e.g., hostedPaymentReturnOptions).
+     * @param mixed $value
+     *   The value, which will be JSON-encoded if it's an array.
+     */
+    public function __construct(string $name, $value)
+    {
+        parent::__construct();
+        $this->properties['settingName'] = $name;
+        // Encode the value.
+        if (is_array($value)) {
+            $value = json_encode($value, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
+        }
+        $this->properties['settingValue'] = $value;
+    }
+
+}

--- a/src/GetCustomerProfileRequest.php
+++ b/src/GetCustomerProfileRequest.php
@@ -13,6 +13,7 @@ use CommerceGuys\AuthNet\Request\RequestInterface;
 class GetCustomerProfileRequest extends BaseApiRequest
 {
     protected $customerProfileId;
+    protected $unmaskExpirationDate = false;
 
     public function __construct(
         Configuration $configuration,
@@ -23,8 +24,19 @@ class GetCustomerProfileRequest extends BaseApiRequest
         $this->customerProfileId = $customerProfileId;
     }
 
-    protected function attachData(RequestInterface $request)
+    /**
+     * @param boolean $unmaskExpirationDate
+     */
+    public function setUnmaskExpirationDate($unmaskExpirationDate)
+    {
+       $this->unmaskExpirationDate = $unmaskExpirationDate;
+    }
+
+	protected function attachData(RequestInterface $request)
     {
         $request->addData('customerProfileId', $this->customerProfileId);
+        if ($this->unmaskExpirationDate) {
+            $request->addData('unmaskExpirationDate', $this->unmaskExpirationDate);
+        }
     }
 }

--- a/src/GetHostedPaymentPageRequest.php
+++ b/src/GetHostedPaymentPageRequest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace CommerceGuys\AuthNet;
+
+use CommerceGuys\AuthNet\DataTypes\HostedPaymentSettings;
+use CommerceGuys\AuthNet\DataTypes\TransactionRequest;
+use CommerceGuys\AuthNet\Request\RequestInterface;
+use GuzzleHttp\Client;
+
+/**
+ * Retrieves a token to launch the Accept Hosted payment form.
+ *
+ * @link https://developer.authorize.net/api/reference/index.html#accept-suite-get-an-accept-payment-page
+ */
+class GetHostedPaymentPageRequest extends BaseApiRequest
+{
+    /**
+     * @var \CommerceGuys\AuthNet\DataTypes\TransactionRequest|null
+     */
+    protected $transactionRequest;
+
+    /**
+     * @var \CommerceGuys\AuthNet\DataTypes\HostedPaymentSettings|null;
+     */
+    protected $hostedPaymentSettings;
+
+    /**
+     * Constructs a new GetHostedPaymentPageRequest object.
+     *
+     * @param Configuration $configuration
+     *   The configuration object containing API credentials.
+     * @param Client $client
+     *   The HTTP client for making requests.
+     * @param \CommerceGuys\AuthNet\DataTypes\TransactionRequest|null $transactionRequest
+     *   The transaction request details.
+     * @param \CommerceGuys\AuthNet\DataTypes\HostedPaymentSettings|null $hostedPaymentSettings
+     *   The settings for the Accept Hosted payment form.
+     */
+    public function __construct(
+        Configuration $configuration,
+        Client $client,
+        TransactionRequest $transactionRequest = null,
+        HostedPaymentSettings $hostedPaymentSettings = null
+    ) {
+        parent::__construct($configuration, $client);
+        $this->transactionRequest = $transactionRequest;
+        $this->hostedPaymentSettings = $hostedPaymentSettings;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function attachData(RequestInterface $request)
+    {
+        // Attach transaction details.
+        if ($this->transactionRequest) {
+            $request->addDataType($this->transactionRequest);
+        }
+        // Add hosted payment settings.
+        if ($this->hostedPaymentSettings) {
+            $request->addDataType($this->hostedPaymentSettings);
+        }
+    }
+
+    /**
+     * Sets the transaction request.
+     *
+     * @param \CommerceGuys\AuthNet\DataTypes\TransactionRequest $transactionRequest
+     *   The transaction details.
+     *
+     * @return $this
+     */
+    public function setTransactionRequest(TransactionRequest $transactionRequest)
+    {
+        $this->transactionRequest = $transactionRequest;
+        return $this;
+    }
+
+    /**
+     * Sets the hosted payment settings.
+     *
+     * @param \CommerceGuys\AuthNet\DataTypes\HostedPaymentSettings $hostedPaymentSettings
+     *
+     * @return $this
+     */
+    public function setHostedPaymentSettings(HostedPaymentSettings $hostedPaymentSettings)
+    {
+        $this->hostedPaymentSettings = $hostedPaymentSettings;
+        return $this;
+    }
+}

--- a/tests/ARBCreateSubscriptionRequestTest.php
+++ b/tests/ARBCreateSubscriptionRequestTest.php
@@ -20,7 +20,7 @@ class ARBCreateSubscriptionRequestTest extends TestBase
     {
         $interval = new Interval(['length' => 7, 'unit' => 'days']);
         $paymentSchedule = new PaymentSchedule([
-            'startDate' => '2024-08-30',
+            'startDate' => (new \DateTime('+1 day'))->format('Y-m-d'),
             'totalOccurrences' => 9999,
         ]);
         $paymentSchedule->addInterval($interval);

--- a/tests/AuthenticateRequestTest.php
+++ b/tests/AuthenticateRequestTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace CommerceGuys\AuthNet\Tests;
+
+use CommerceGuys\AuthNet\AuthenticateTestRequest;
+use CommerceGuys\AuthNet\DataTypes\MerchantAuthentication;
+use CommerceGuys\AuthNet\Tests\TestBase;
+
+/**
+ * Tests the AuthenticateTestRequest.
+ *
+ * This test verifies that the provided merchant credentials are valid
+ * using both XML and JSON formats.
+ */
+class AuthenticateTestRequestTest extends TestBase
+{
+    /**
+     * Tests the authenticateTestRequest using XML format.
+     */
+    public function testAuthenticateTestXml(): void
+    {
+        $request = new AuthenticateTestRequest(
+            $this->configurationXml,
+            $this->client
+        );
+
+        // Explicitly set authentication in case configuration does not preload it.
+        $request->setMerchantAuthentication(new MerchantAuthentication([
+            'name' => $this->configurationXml->getApiLogin(),
+            'transactionKey' => $this->configurationXml->getTransactionKey(),
+        ]));
+
+        /** @var \CommerceGuys\AuthNet\Response\XmlResponse $response */
+        $response = $request->execute();
+
+        $this->assertEquals('Ok', $response->getResultCode());
+        $this->assertEquals('I00001', $response->getMessages()[0]->getCode());
+        $this->assertEquals('Successful.', $response->getMessages()[0]->getText());
+    }
+
+    /**
+     * Tests the authenticateTestRequest using JSON format.
+     */
+    public function testAuthenticateTestJson(): void
+    {
+        $request = new AuthenticateTestRequest(
+            $this->configurationJson,
+            $this->client
+        );
+
+        $request->setMerchantAuthentication(new MerchantAuthentication([
+            'name' => $this->configurationJson->getApiLogin(),
+            'transactionKey' => $this->configurationJson->getTransactionKey(),
+        ]));
+
+        /** @var \CommerceGuys\AuthNet\Response\JsonResponse $response */
+        $response = $request->execute();
+
+        $this->assertEquals('Ok', $response->getResultCode());
+        $this->assertEquals('I00001', $response->getMessages()[0]->getCode());
+        $this->assertEquals('Successful.', $response->getMessages()[0]->getText());
+    }
+}

--- a/tests/CustomerProfileFromTransactionRequestTest.php
+++ b/tests/CustomerProfileFromTransactionRequestTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace CommerceGuys\AuthNet\Tests;
+
+use CommerceGuys\AuthNet\CreateCustomerProfileFromTransactionRequest;
+use CommerceGuys\AuthNet\DataTypes\TransactionRequest;
+use CommerceGuys\AuthNet\Tests\CreateTransactionRequest\CreateTransactionRequestTestBase;
+
+class CustomerProfileFromTransactionRequestTest extends CreateTransactionRequestTestBase
+{
+    /**
+     * Tests the request with XML format.
+     */
+    public function testCreateCustomerProfileFromTransactionXml()
+    {
+        // Create a transaction with customer and billing info (required).
+        $transactionRequest = $this->createChargableTransactionRequest(TransactionRequest::AUTH_ONLY);
+        $transactionRequest->addData('customer', [
+            'email' => 'xml_test@example.com',
+        ]);
+        $transactionRequest->addData('billTo', [
+            'firstName' => 'Jane',
+            'lastName' => 'Doe',
+            'address' => '456 Elm St',
+            'city' => 'Springfield',
+            'state' => 'IL',
+            'zip' => '62704',
+            'country' => 'US',
+            'phoneNumber' => '5555555555',
+        ]);
+
+        $transactionResponse = $this->xmlRequestFactory
+            ->createTransactionRequest()
+            ->setTransactionRequest($transactionRequest)
+            ->execute();
+
+        $this->assertEquals('Ok', $transactionResponse->getResultCode());
+        $transId = $transactionResponse->transactionResponse->transId ?? null;
+
+        $this->assertNotEmpty($transId, 'Transaction ID should not be empty');
+
+        $request = new CreateCustomerProfileFromTransactionRequest(
+            $this->configurationXml,
+            $this->client,
+            $transId
+        );
+        /** @var \CommerceGuys\AuthNet\Response\XmlResponse $response */
+        $response = $request->execute();
+        $contents = $response->contents();
+
+        $this->assertEquals('Ok', $response->getResultCode());
+        $this->assertEquals('I00001', $response->getMessages()[0]->getCode());
+        $this->assertEquals('Successful.', $response->getMessages()[0]->getText());
+
+        $this->assertTrue(property_exists($contents, 'customerProfileId'));
+        $this->assertNotEmpty($contents->customerProfileId);
+
+        $this->assertListFieldContainsData($contents, 'customerPaymentProfileIdList');
+        $this->assertListFieldContainsData($contents, 'customerShippingAddressIdList');
+
+        $this->assertTrue(property_exists($contents, 'validationDirectResponseList'));
+        $this->assertInstanceOf(\stdClass::class, $contents->validationDirectResponseList);
+    }
+
+    /**
+     * Tests the request with JSON format.
+     */
+    public function testCreateCustomerProfileFromTransactionJson()
+    {
+        // Use a new number, otherwise a duplicate transaction is flagged.
+        $transactionRequest = $this->createChargableTransactionRequest(
+            TransactionRequest::AUTH_ONLY,
+            '4007000000027'
+        );
+        $transactionRequest->addData('customer', [
+            'email' => 'json_test@example.com',
+        ]);
+        $transactionRequest->addData('billTo', [
+            'firstName' => 'John',
+            'lastName' => 'Smith',
+            'address' => '789 Oak St',
+            'city' => 'Columbus',
+            'state' => 'OH',
+            'zip' => '43004',
+            'country' => 'US',
+            'phoneNumber' => '5555555555',
+        ]);
+        // Create the transaction.
+        $transactionResponse = $this->jsonRequestFactory
+            ->createTransactionRequest()
+            ->setTransactionRequest($transactionRequest)
+            ->execute();
+
+        $this->assertEquals('Ok', $transactionResponse->getResultCode());
+        $transId = $transactionResponse->transactionResponse->transId ?? null;
+
+        $this->assertNotEmpty($transId, 'Transaction ID should not be empty');
+
+        // Create the customer profile from the transaction.
+        $request = new CreateCustomerProfileFromTransactionRequest(
+            $this->configurationJson,
+            $this->client,
+            $transId
+        );
+        /** @var \CommerceGuys\AuthNet\Response\JsonResponse $response */
+        $response = $request->execute();
+        $contents = $response->contents();
+
+        $this->assertEquals('Ok', $response->getResultCode());
+        $this->assertEquals('I00001', $response->getMessages()[0]->getCode());
+        $this->assertEquals('Successful.', $response->getMessages()[0]->getText());
+
+        $this->assertTrue(property_exists($contents, 'customerProfileId'));
+        $this->assertNotEmpty($contents->customerProfileId);
+
+        $this->assertIsArray($contents->customerPaymentProfileIdList);
+        $this->assertNotEmpty($contents->customerPaymentProfileIdList);
+
+        $this->assertIsArray($contents->customerShippingAddressIdList);
+        $this->assertNotEmpty($contents->customerShippingAddressIdList);
+
+        $this->assertIsArray($contents->validationDirectResponseList);
+    }
+
+    /**
+     * Helper for handling list fields that return stdClass with numericString in XML.
+     */
+    protected function assertListFieldContainsData($object, string $fieldName): void
+    {
+        $this->assertTrue(property_exists($object, $fieldName));
+        $list = (array) $object->{$fieldName};
+        $this->assertArrayHasKey('numericString', $list, "$fieldName must contain numericString key");
+        $this->assertNotEmpty($list['numericString'], "$fieldName.numericString must not be empty");
+    }
+}

--- a/tests/CustomerProfileRequestTest.php
+++ b/tests/CustomerProfileRequestTest.php
@@ -59,6 +59,7 @@ class CustomerProfileRequestTest extends TestBase
         $this->assertTrue(isset($response->validationDirectResponseList));
 
         $request = new GetCustomerProfileRequest($this->configurationXml, $this->client, $response->customerProfileId);
+        $request->setUnmaskExpirationDate(false);
         $response = $request->execute();
         $this->assertResponse($response, 'I00001', 'Successful.', 'Ok');
         $this->assertTrue(isset($response->profile));

--- a/tests/DataType/HostedPaymentSettingsTest.php
+++ b/tests/DataType/HostedPaymentSettingsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace CommerceGuys\AuthNet\Tests\DataType;
+
+use CommerceGuys\AuthNet\DataTypes\HostedPaymentSettings;
+use CommerceGuys\AuthNet\DataTypes\Setting;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the HostedPaymentSettings class.
+ */
+class HostedPaymentSettingsTest extends TestCase
+{
+    /**
+     * Tests that settings are added and structured properly.
+     */
+    public function testAddSingleSetting()
+    {
+        $settingName = 'hostedPaymentReturnOptions';
+        $settingValue = [
+            'showReceipt' => false,
+            'url' => 'https://example.com/return',
+        ];
+        $settings = new HostedPaymentSettings();
+        $settings->addSetting(new Setting($settingName, $settingValue));
+
+        $array = $settings->toArray();
+
+        $this->assertCount(1, $array);
+        $this->assertArrayHasKey('setting', $array[0]);
+        $this->assertEquals('hostedPaymentReturnOptions', $array[0]['setting']['settingName']);
+
+        $expectedValue = json_encode($settingValue);
+        $this->assertJsonStringEqualsJsonString($expectedValue, $array[0]['setting']['settingValue']);
+    }
+
+    /**
+     * Tests adding multiple settings.
+     */
+    public function testAddMultipleSettings()
+    {
+        $settings = new HostedPaymentSettings();
+
+        $settings->addSetting(new Setting('hostedPaymentBillingAddressOptions', ['show' => false]));
+        $settings->addSetting(new Setting('hostedPaymentSecurityOptions', ['captcha' => true]));
+
+        $array = $settings->toArray();
+
+        $this->assertCount(2, $array);
+
+        $this->assertEquals('hostedPaymentBillingAddressOptions', $array[0]['setting']['settingName']);
+        $this->assertEquals(json_encode(['show' => false]), $array[0]['setting']['settingValue']);
+
+        $this->assertEquals('hostedPaymentSecurityOptions', $array[1]['setting']['settingName']);
+        $this->assertEquals(json_encode(['captcha' => true]), $array[1]['setting']['settingValue']);
+    }
+
+    /**
+     * Tests that a scalar string value does not get double-encoded.
+     */
+    public function testScalarSettingValue()
+    {
+        $settings = new HostedPaymentSettings();
+        $settings->addSetting(new Setting('customLabel', 'Some Value'));
+
+        $array = $settings->toArray();
+
+        $this->assertEquals('Some Value', $array[0]['setting']['settingValue']);
+    }
+}

--- a/tests/GetHostedPaymentPageRequestTest.php
+++ b/tests/GetHostedPaymentPageRequestTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace CommerceGuys\AuthNet\Tests;
+
+use CommerceGuys\AuthNet\DataTypes\HostedPaymentSettings;
+use CommerceGuys\AuthNet\DataTypes\Setting;
+use CommerceGuys\AuthNet\DataTypes\TransactionRequest;
+use CommerceGuys\AuthNet\GetHostedPaymentPageRequest;
+use CommerceGuys\AuthNet\Tests\CreateTransactionRequest\CreateTransactionRequestTestBase;
+
+class GetHostedPaymentPageRequestTest extends CreateTransactionRequestTestBase
+{
+    /**
+     * Tests the Accept Hosted request with XML format.
+     */
+    public function testGetHostedPaymentPageXml()
+    {
+        // Minimal valid transaction request for Accept Hosted.
+        $transactionRequest = new TransactionRequest([
+            'transactionType' => TransactionRequest::AUTH_ONLY,
+            'amount' => '50.00',
+        ]);
+        // Minimal hosted payment settings.
+        $hostedSettings = new HostedPaymentSettings();
+        $hostedSettings->addSetting(new Setting('hostedPaymentReturnOptions', [
+            'showReceipt' => true,
+            'url' => 'https://mysite.com/receipt',
+            'urlText' => 'Continue',
+            'cancelUrl' => 'https://mysite.com/cancel',
+            'cancelUrlText' => 'Cancel',
+        ]));
+        $request = new GetHostedPaymentPageRequest(
+            $this->configurationXml,
+            $this->client,
+            $transactionRequest,
+            $hostedSettings
+        );
+
+        /** @var \CommerceGuys\AuthNet\Response\XmlResponse $response */
+        $response = $request->execute();
+        $contents = $response->contents();
+
+        $this->assertEquals('Ok', $response->getResultCode());
+        $this->assertEquals('I00001', $response->getMessages()[0]->getCode());
+        $this->assertEquals('Successful.', $response->getMessages()[0]->getText());
+
+        $this->assertTrue(property_exists($contents, 'token'));
+        $this->assertNotEmpty($contents->token);
+    }
+
+    /**
+     * Tests the Accept Hosted request with JSON format.
+     */
+    public function testGetHostedPaymentPageJson()
+    {
+        // Minimal valid transaction request for Accept Hosted.
+        $transactionRequest = new TransactionRequest([
+            'transactionType' => TransactionRequest::AUTH_CAPTURE,
+            'amount' => '20.00',
+        ]);
+        // Minimal hosted payment settings.
+        $hostedSettings = new HostedPaymentSettings();
+        $hostedSettings->addSetting(new Setting('hostedPaymentReturnOptions', [
+            'showReceipt' => true,
+            'url' => 'https://mysite.com/receipt',
+            'urlText' => 'Continue',
+            'cancelUrl' => 'https://mysite.com/cancel',
+            'cancelUrlText' => 'Cancel'
+        ]));
+
+        $request = new GetHostedPaymentPageRequest(
+            $this->configurationJson,
+            $this->client
+        );
+        $request->setTransactionRequest($transactionRequest);
+        $request->setHostedPaymentSettings($hostedSettings);
+
+        /** @var \CommerceGuys\AuthNet\Response\JsonResponse $response */
+        $response = $request->execute();
+        $contents = $response->contents();
+
+        $this->assertEquals('Ok', $response->getResultCode());
+        $this->assertEquals('I00001', $response->getMessages()[0]->getCode());
+        $this->assertEquals('Successful.', $response->getMessages()[0]->getText());
+
+        $this->assertTrue(property_exists($contents, 'token'));
+        $this->assertNotEmpty($contents->token);
+    }
+}


### PR DESCRIPTION
This PR introduces the following features to the SDK:

1. **New API request classes:**

    * `GetHostedPaymentPageRequest`: Retrieves a token to launch the Accept Hosted form.
    * `CreateCustomerProfileFromTransactionRequest`: Creates a customer profile using a previous successful transaction.

2. **New data types:**

    * `HostedPaymentSettings`: Represents a list of hosted payment configuration settings.
    * `Setting`: A single key/value setting used within `HostedPaymentSettings`.

3. **Enhancements:**

    * `GetCustomerProfileRequest`: Adds support for the `unmaskExpirationDate` option.

4. **Test coverage:**

    * Unit tests added for `HostedPaymentSettings`, `GetHostedPaymentPageRequest`, and `CreateCustomerProfileFromTransactionRequest` with both XML and JSON response validation.

These additions enable more robust integration with Authorize.Net's Accept Hosted and customer profile APIs.